### PR TITLE
refactor: 서버 디렉토리 구조 개편

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 ## 동작
 
 - 실행 시 `http://127.0.0.1:8080` 에 서버를 띄웁니다.
-- `POST /submit` 경로에 `{ language: String, code: String }` 형태의 JSON 데이터를 받습니다.
+- `POST /api/v1/submit` 경로에 `{ language: String, code: String }` 형태의 JSON 데이터를 받습니다.
 - 받은 데이터를 language 에 따라 비동기적으로 컴파일하고 실행합니다.
 - 실행 결과를 JSON 형태로 반환합니다.
 
@@ -16,7 +16,7 @@
   - isolate 가 매 실행마다 격리된 box를 생성합니다.
   - 해당 box 안에 코드를 저장하고, `node` `gcc` `python3` 등의 도구를 이용하여 컴파일 및 실행합니다.
   - 실행이 끝나면 isolate 를 통해 격리된 box를 제거합니다.
-- API 콜 테스트 및 자동화 테스트에는 Bruno 를 활용합니다. Bruno Collection 은 [여기](./tests/bruno) 에 있습니다.
+- API 콜 테스트 및 자동화 테스트에는 Bruno 를 활용합니다. Bruno Collection 은 [여기](./hodu-server/tests/bruno) 에 있습니다.
 
 ## 배포
 

--- a/hodu-server/src/api.rs
+++ b/hodu-server/src/api.rs
@@ -1,0 +1,10 @@
+use actix_web::{dev::HttpServiceFactory, web};
+
+mod judge;
+mod ping;
+
+pub fn v1_router() -> impl HttpServiceFactory {
+    web::scope("/api/v1")
+        .service(ping::view::ping)
+        .service(judge::view::submit_code)
+}

--- a/hodu-server/src/api/judge.rs
+++ b/hodu-server/src/api/judge.rs
@@ -1,0 +1,2 @@
+mod schema;
+pub mod view;

--- a/hodu-server/src/api/judge/schema.rs
+++ b/hodu-server/src/api/judge/schema.rs
@@ -1,0 +1,8 @@
+use hodu_core::Language;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct CodeSubmission {
+    pub language: Language,
+    pub code: String,
+}

--- a/hodu-server/src/api/judge/view.rs
+++ b/hodu-server/src/api/judge/view.rs
@@ -1,0 +1,11 @@
+use actix_web::{post, web, Responder};
+use hodu_core::mark_code;
+
+use crate::api::judge::schema::CodeSubmission;
+
+#[post("/submit")]
+async fn submit_code(submission: web::Json<CodeSubmission>) -> impl Responder {
+    let output = mark_code(&submission.language, submission.code.clone()).await;
+
+    web::Json(output)
+}

--- a/hodu-server/src/api/ping.rs
+++ b/hodu-server/src/api/ping.rs
@@ -1,0 +1,1 @@
+pub mod view;

--- a/hodu-server/src/api/ping/view.rs
+++ b/hodu-server/src/api/ping/view.rs
@@ -1,0 +1,6 @@
+use actix_web::{get, Responder};
+
+#[get("/ping")]
+pub async fn ping() -> impl Responder {
+    "pong"
+}

--- a/hodu-server/src/main.rs
+++ b/hodu-server/src/main.rs
@@ -1,30 +1,10 @@
-use actix_web::{get, post, web, App, HttpServer, Responder};
-use serde::Deserialize;
+use actix_web::{App, HttpServer};
 
-extern crate hodu_core;
-use hodu_core::{mark_code, Language};
-
-#[derive(Deserialize)]
-struct CodeSubmission {
-    language: Language,
-    code: String,
-}
-
-#[get("/ping")]
-async fn ping() -> impl Responder {
-    "pong"
-}
-
-#[post("/submit")]
-async fn submit_code(submission: web::Json<CodeSubmission>) -> impl Responder {
-    let output = mark_code(&submission.language, submission.code.clone()).await;
-
-    web::Json(output)
-}
+mod api;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    HttpServer::new(|| App::new().service(ping).service(submit_code))
+    HttpServer::new(|| App::new().service(api::v1_router()))
         .bind("0.0.0.0:8080")?
         .run()
         .await

--- a/hodu-server/tests/bruno/[c++] stars.bru
+++ b/hodu-server/tests/bruno/[c++] stars.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: http://127.0.0.1:8080/submit
+  url: http://127.0.0.1:8080/api/v1/submit
   body: json
   auth: none
 }

--- a/hodu-server/tests/bruno/[c] stars.bru
+++ b/hodu-server/tests/bruno/[c] stars.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: http://127.0.0.1:8080/submit
+  url: http://127.0.0.1:8080/api/v1/submit
   body: json
   auth: none
 }

--- a/hodu-server/tests/bruno/[java] single print.bru
+++ b/hodu-server/tests/bruno/[java] single print.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: http://127.0.0.1:8080/submit
+  url: http://127.0.0.1:8080/api/v1/submit
   body: json
   auth: none
 }

--- a/hodu-server/tests/bruno/[javascript] single print.bru
+++ b/hodu-server/tests/bruno/[javascript] single print.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: http://127.0.0.1:8080/submit
+  url: http://127.0.0.1:8080/api/v1/submit
   body: json
   auth: none
 }

--- a/hodu-server/tests/bruno/[python] single print.bru
+++ b/hodu-server/tests/bruno/[python] single print.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: http://127.0.0.1:8080/submit
+  url: http://127.0.0.1:8080/api/v1/submit
   body: json
   auth: none
 }

--- a/hodu-server/tests/bruno/compile-errors/[c] no semicolon.bru
+++ b/hodu-server/tests/bruno/compile-errors/[c] no semicolon.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: http://127.0.0.1:8080/submit
+  url: http://127.0.0.1:8080/api/v1/submit
   body: json
   auth: none
 }

--- a/hodu-server/tests/bruno/hacks/[c] run shell - shutdown.bru
+++ b/hodu-server/tests/bruno/hacks/[c] run shell - shutdown.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: http://127.0.0.1:8080/submit
+  url: http://127.0.0.1:8080/api/v1/submit
   body: json
   auth: none
 }

--- a/hodu-server/tests/bruno/hacks/[node] run shell - try to get structure.bru
+++ b/hodu-server/tests/bruno/hacks/[node] run shell - try to get structure.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: http://127.0.0.1:8080/submit
+  url: http://127.0.0.1:8080/api/v1/submit
   body: json
   auth: none
 }


### PR DESCRIPTION
## 기존 코드의 문제점
기존 코드는 PoC (#1) 에서 잡힌 뼈대를 그대로 이용하고 있어, `main.rs` 모든 코드가 집중되어 있습니다.

## 리팩토링 방법
프로젝트가 더 비대해지기 전에 일반적인 서버 애플리케이션들의 사례를 참고하여 코드를 분리하고 디렉토리 구조를 개편합니다.
