### PR TITLE
♻️ LanguageExecutor&Sandbox 인터페이스화, API 규격 language 필드 case 변경

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,7 @@ name = "hodu-core"
 version = "0.1.0"
 dependencies = [
  "rand",
+ "regex",
  "serde",
  "serde_json",
  "thiserror",
@@ -878,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,12 +541,8 @@ version = "0.1.0"
 dependencies = [
  "rand",
  "regex",
- "serde",
- "serde_json",
  "thiserror",
  "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -558,7 +554,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tokio",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/hodu-core/Cargo.toml
+++ b/hodu-core/Cargo.toml
@@ -6,9 +6,5 @@ edition = "2021"
 [dependencies]
 rand = "0.8.5"
 regex = "1.10.6"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 thiserror = "1.0.63"
 tokio = { version = "1.0", features = ["full"] }
-tracing = "0.1"
-tracing-subscriber = "0.3"

--- a/hodu-core/Cargo.toml
+++ b/hodu-core/Cargo.toml
@@ -5,9 +5,10 @@ edition = "2021"
 
 [dependencies]
 rand = "0.8.5"
-tokio = { version = "1.0", features = ["full"] }
+regex = "1.10.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+thiserror = "1.0.63"
+tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
-thiserror = "1.0.63"

--- a/hodu-core/src/error.rs
+++ b/hodu-core/src/error.rs
@@ -1,7 +1,2 @@
-use crate::sandbox::isolate;
-
 #[derive(thiserror::Error, Debug)]
-pub enum HoduCoreError {
-    #[error("IsolateError: {0}")]
-    IsolateError(#[source] isolate::Error),
-}
+pub enum HoduCoreError {}

--- a/hodu-core/src/languages.rs
+++ b/hodu-core/src/languages.rs
@@ -1,4 +1,4 @@
-use crate::sandbox::{ExecutionResult, Sandbox};
+use crate::sandbox::Sandbox;
 
 pub mod c;
 pub mod cpp;
@@ -8,4 +8,20 @@ pub mod python;
 
 pub trait LanguageExecutor {
     async fn run<S: Sandbox>(&self, code: &str, sandbox: &S) -> ExecutionResult;
+}
+
+pub struct ExecutionSuccessOutput {
+    pub time: f64,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+pub struct ExecutionErrorOutput {
+    pub stdout: String,
+    pub stderr: String,
+}
+
+pub enum ExecutionResult {
+    Success(ExecutionSuccessOutput),
+    CompileError(ExecutionErrorOutput),
 }

--- a/hodu-core/src/languages.rs
+++ b/hodu-core/src/languages.rs
@@ -1,47 +1,11 @@
-use serde::{Deserialize, Serialize};
+use crate::sandbox::{ExecutionResult, Sandbox};
 
-use crate::error::HoduCoreError;
+pub mod c;
+pub mod cpp;
+pub mod java;
+pub mod javascript;
+pub mod python;
 
-mod c;
-mod cpp;
-mod java;
-mod javascript;
-mod python;
-
-#[derive(Deserialize, Debug)]
-pub enum Language {
-    C,
-    CPP,
-    JAVA,
-    PYTHON,
-    JAVASCRIPT,
-}
-
-#[derive(Serialize)]
-pub struct ExecutionResult {
-    pub stdout: String,
-    pub stderr: String,
-    pub success: bool,
-}
-
-pub struct ExecutionParams {
-    pub code: String,
-    pub filename: String,
-    pub compile_command: Option<ExecutionCommand>,
-    pub execute_command: ExecutionCommand,
-}
-
-pub struct ExecutionCommand {
-    pub binary: String,
-    pub args: Vec<String>,
-}
-
-pub async fn mark_code(language: &Language, code: String) -> Result<ExecutionResult, HoduCoreError> {
-    match language {
-        Language::C => c::run_c_code(&code).await,
-        Language::CPP => cpp::run_cpp_code(&code).await,
-        Language::JAVA => java::run_java_code(&code).await,
-        Language::PYTHON => python::run_python_code(&code).await,
-        Language::JAVASCRIPT => javascript::run_javascript_code(&code).await,
-    }
+pub trait LanguageExecutor {
+    async fn run<S: Sandbox>(&self, code: &str, sandbox: &S) -> ExecutionResult;
 }

--- a/hodu-core/src/languages.rs
+++ b/hodu-core/src/languages.rs
@@ -7,7 +7,7 @@ pub mod javascript;
 pub mod python;
 
 pub trait LanguageExecutor {
-    async fn run<S: Sandbox>(&self, code: &str, sandbox: &S) -> ExecutionResult;
+    async fn run(&self, code: &str, sandbox: &impl Sandbox) -> ExecutionResult;
 }
 
 pub struct ExecutionSuccessOutput {

--- a/hodu-core/src/languages/c.rs
+++ b/hodu-core/src/languages/c.rs
@@ -1,25 +1,40 @@
-use super::{ExecutionCommand, ExecutionParams, ExecutionResult};
-use crate::{error::HoduCoreError, sandbox::isolate::execute_isolate};
+use crate::sandbox::{ExecutionCommand, ExecutionResult, Sandbox};
 
-pub async fn run_c_code(code: &str) -> Result<ExecutionResult, HoduCoreError> {
-    execute_isolate(ExecutionParams {
-        code: code.to_string(),
-        filename: "./main.c".to_string(),
-        compile_command: Some(ExecutionCommand {
-            binary: "gcc".to_string(),
-            args: vec![
-                "-o".to_string(),
-                "./main".to_string(),
-                "./main.c".to_string(),
-            ],
-        }),
-        execute_command: {
-            ExecutionCommand {
-                binary: "./main".to_string(),
-                args: vec![],
-            }
-        },
-    })
-    .await
-    .map_err(HoduCoreError::IsolateError)
+use super::LanguageExecutor;
+
+pub struct CExecutor {}
+
+impl LanguageExecutor for CExecutor {
+    async fn run<S: Sandbox>(&self, code: &str, sandbox: &S) -> ExecutionResult {
+        sandbox.add_file("./main.c", code).await;
+
+        let compile_result = sandbox
+            .execute(
+                ExecutionCommand {
+                    binary: "gcc",
+                    args: vec!["-o", "./main", "./main.c"],
+                },
+                false,
+            )
+            .await;
+
+        if !compile_result.success {
+            return ExecutionResult {
+                output: compile_result.output,
+                success: false,
+            };
+        }
+
+        let execute_result = sandbox
+            .execute(
+                ExecutionCommand {
+                    binary: "./main",
+                    args: vec![],
+                },
+                true,
+            )
+            .await;
+
+        execute_result
+    }
 }

--- a/hodu-core/src/languages/c.rs
+++ b/hodu-core/src/languages/c.rs
@@ -1,6 +1,6 @@
-use crate::sandbox::{ExecutionCommand, ExecutionResult, Sandbox};
+use crate::sandbox::{Sandbox, SandboxCommand};
 
-use super::LanguageExecutor;
+use super::{ExecutionErrorOutput, ExecutionResult, ExecutionSuccessOutput, LanguageExecutor};
 
 pub struct CExecutor {}
 
@@ -10,7 +10,7 @@ impl LanguageExecutor for CExecutor {
 
         let compile_result = sandbox
             .execute(
-                ExecutionCommand {
+                SandboxCommand {
                     binary: "gcc",
                     args: vec!["-o", "./main", "./main.c"],
                 },
@@ -19,15 +19,15 @@ impl LanguageExecutor for CExecutor {
             .await;
 
         if !compile_result.success {
-            return ExecutionResult {
-                output: compile_result.output,
-                success: false,
-            };
+            return ExecutionResult::CompileError(ExecutionErrorOutput {
+                stdout: compile_result.stdout,
+                stderr: compile_result.stderr,
+            });
         }
 
         let execute_result = sandbox
             .execute(
-                ExecutionCommand {
+                SandboxCommand {
                     binary: "./main",
                     args: vec![],
                 },
@@ -35,6 +35,10 @@ impl LanguageExecutor for CExecutor {
             )
             .await;
 
-        execute_result
+        ExecutionResult::Success(ExecutionSuccessOutput {
+            stdout: execute_result.stdout,
+            stderr: execute_result.stderr,
+            time: execute_result.time,
+        })
     }
 }

--- a/hodu-core/src/languages/c.rs
+++ b/hodu-core/src/languages/c.rs
@@ -5,7 +5,7 @@ use super::{ExecutionErrorOutput, ExecutionResult, ExecutionSuccessOutput, Langu
 pub struct CExecutor {}
 
 impl LanguageExecutor for CExecutor {
-    async fn run<S: Sandbox>(&self, code: &str, sandbox: &S) -> ExecutionResult {
+    async fn run(&self, code: &str, sandbox: &impl Sandbox) -> ExecutionResult {
         sandbox.add_file("./main.c", code).await;
 
         let compile_result = sandbox

--- a/hodu-core/src/languages/cpp.rs
+++ b/hodu-core/src/languages/cpp.rs
@@ -5,7 +5,7 @@ use super::{ExecutionErrorOutput, ExecutionResult, ExecutionSuccessOutput, Langu
 pub struct CppExecutor {}
 
 impl LanguageExecutor for CppExecutor {
-    async fn run<S: Sandbox>(&self, code: &str, sandbox: &S) -> ExecutionResult {
+    async fn run(&self, code: &str, sandbox: &impl Sandbox) -> ExecutionResult {
         sandbox.add_file("./main.cpp", code).await;
 
         let compile_result = sandbox

--- a/hodu-core/src/languages/cpp.rs
+++ b/hodu-core/src/languages/cpp.rs
@@ -1,6 +1,6 @@
-use crate::sandbox::{ExecutionCommand, ExecutionResult, Sandbox};
+use crate::sandbox::{Sandbox, SandboxCommand};
 
-use super::LanguageExecutor;
+use super::{ExecutionErrorOutput, ExecutionResult, ExecutionSuccessOutput, LanguageExecutor};
 
 pub struct CppExecutor {}
 
@@ -10,7 +10,7 @@ impl LanguageExecutor for CppExecutor {
 
         let compile_result = sandbox
             .execute(
-                ExecutionCommand {
+                SandboxCommand {
                     binary: "g++",
                     args: vec!["-o", "./main", "./main.cpp"],
                 },
@@ -19,12 +19,15 @@ impl LanguageExecutor for CppExecutor {
             .await;
 
         if !compile_result.success {
-            return compile_result;
+            return ExecutionResult::CompileError(ExecutionErrorOutput {
+                stdout: compile_result.stdout,
+                stderr: compile_result.stderr,
+            });
         }
 
         let execute_result = sandbox
             .execute(
-                ExecutionCommand {
+                SandboxCommand {
                     binary: "./main",
                     args: vec![],
                 },
@@ -32,6 +35,10 @@ impl LanguageExecutor for CppExecutor {
             )
             .await;
 
-        execute_result
+        ExecutionResult::Success(ExecutionSuccessOutput {
+            stdout: execute_result.stdout,
+            stderr: execute_result.stderr,
+            time: execute_result.time,
+        })
     }
 }

--- a/hodu-core/src/languages/java.rs
+++ b/hodu-core/src/languages/java.rs
@@ -8,7 +8,7 @@ use super::{ExecutionErrorOutput, ExecutionResult, ExecutionSuccessOutput, Langu
 pub struct JavaExecutor {}
 
 impl LanguageExecutor for JavaExecutor {
-    async fn run<S: Sandbox>(&self, code: &str, sandbox: &S) -> ExecutionResult {
+    async fn run(&self, code: &str, sandbox: &impl Sandbox) -> ExecutionResult {
         sandbox.add_file("./Main.java", code).await;
 
         let java = get_binary_path("java").await;

--- a/hodu-core/src/languages/java.rs
+++ b/hodu-core/src/languages/java.rs
@@ -1,9 +1,9 @@
 use crate::{
-    sandbox::{ExecutionCommand, ExecutionResult, Sandbox},
+    sandbox::{Sandbox, SandboxCommand},
     utils::get_binary_path::get_binary_path,
 };
 
-use super::LanguageExecutor;
+use super::{ExecutionErrorOutput, ExecutionResult, ExecutionSuccessOutput, LanguageExecutor};
 
 pub struct JavaExecutor {}
 
@@ -15,7 +15,7 @@ impl LanguageExecutor for JavaExecutor {
 
         let compile_result = sandbox
             .execute(
-                ExecutionCommand {
+                SandboxCommand {
                     binary: "javac",
                     args: vec!["./Main.java"],
                 },
@@ -24,12 +24,15 @@ impl LanguageExecutor for JavaExecutor {
             .await;
 
         if !compile_result.success {
-            return compile_result;
+            return ExecutionResult::CompileError(ExecutionErrorOutput {
+                stdout: compile_result.stdout,
+                stderr: compile_result.stderr,
+            });
         }
 
         let execute_result = sandbox
             .execute(
-                ExecutionCommand {
+                SandboxCommand {
                     binary: &java,
                     args: vec!["Main"],
                 },
@@ -37,6 +40,10 @@ impl LanguageExecutor for JavaExecutor {
             )
             .await;
 
-        execute_result
+        ExecutionResult::Success(ExecutionSuccessOutput {
+            stdout: execute_result.stdout,
+            stderr: execute_result.stderr,
+            time: execute_result.time,
+        })
     }
 }

--- a/hodu-core/src/languages/javascript.rs
+++ b/hodu-core/src/languages/javascript.rs
@@ -1,9 +1,9 @@
 use crate::{
-    sandbox::{ExecutionCommand, ExecutionResult, Sandbox},
+    sandbox::{Sandbox, SandboxCommand},
     utils::get_binary_path::get_binary_path,
 };
 
-use super::LanguageExecutor;
+use super::{ExecutionResult, ExecutionSuccessOutput, LanguageExecutor};
 
 pub struct JavaScriptExecutor {}
 
@@ -15,7 +15,7 @@ impl LanguageExecutor for JavaScriptExecutor {
 
         let execute_result = sandbox
             .execute(
-                ExecutionCommand {
+                SandboxCommand {
                     binary: &node,
                     args: vec!["./main.mjs"],
                 },
@@ -23,6 +23,10 @@ impl LanguageExecutor for JavaScriptExecutor {
             )
             .await;
 
-        execute_result
+        ExecutionResult::Success(ExecutionSuccessOutput {
+            stdout: execute_result.stdout,
+            stderr: execute_result.stderr,
+            time: execute_result.time,
+        })
     }
 }

--- a/hodu-core/src/languages/javascript.rs
+++ b/hodu-core/src/languages/javascript.rs
@@ -8,7 +8,7 @@ use super::{ExecutionResult, ExecutionSuccessOutput, LanguageExecutor};
 pub struct JavaScriptExecutor {}
 
 impl LanguageExecutor for JavaScriptExecutor {
-    async fn run<S: Sandbox>(&self, code: &str, sandbox: &S) -> ExecutionResult {
+    async fn run(&self, code: &str, sandbox: &impl Sandbox) -> ExecutionResult {
         sandbox.add_file("./main.mjs", code).await;
 
         let node = get_binary_path("node").await;

--- a/hodu-core/src/languages/python.rs
+++ b/hodu-core/src/languages/python.rs
@@ -8,7 +8,7 @@ use super::{ExecutionResult, ExecutionSuccessOutput, LanguageExecutor};
 pub struct PythonExecutor {}
 
 impl LanguageExecutor for PythonExecutor {
-    async fn run<S: Sandbox>(&self, code: &str, sandbox: &S) -> ExecutionResult {
+    async fn run(&self, code: &str, sandbox: &impl Sandbox) -> ExecutionResult {
         sandbox.add_file("./main.py", code).await;
 
         let binary = get_binary_path("python3").await;

--- a/hodu-core/src/languages/python.rs
+++ b/hodu-core/src/languages/python.rs
@@ -1,19 +1,28 @@
-use crate::{error::HoduCoreError, sandbox::isolate::execute_isolate, utils::get_binary_path::get_binary_path};
+use crate::{
+    sandbox::{ExecutionCommand, ExecutionResult, Sandbox},
+    utils::get_binary_path::get_binary_path,
+};
 
-use super::{ExecutionCommand, ExecutionParams, ExecutionResult};
+use super::LanguageExecutor;
 
-pub async fn run_python_code(code: &str) -> Result<ExecutionResult, HoduCoreError> {
-    let python3 = get_binary_path("python3").await;
+pub struct PythonExecutor {}
 
-    execute_isolate(ExecutionParams {
-        code: code.to_string(),
-        filename: "main.py".to_string(),
-        compile_command: None,
-        execute_command: ExecutionCommand {
-            binary: python3,
-            args: vec!["./main.py".to_string()],
-        },
-    })
-    .await
-    .map_err(HoduCoreError::IsolateError)
+impl LanguageExecutor for PythonExecutor {
+    async fn run<S: Sandbox>(&self, code: &str, sandbox: &S) -> ExecutionResult {
+        sandbox.add_file("./main.py", code).await;
+
+        let binary = get_binary_path("python3").await;
+
+        let execute_result = sandbox
+            .execute(
+                ExecutionCommand {
+                    binary: &binary,
+                    args: vec!["./main.py"],
+                },
+                true,
+            )
+            .await;
+
+        execute_result
+    }
 }

--- a/hodu-core/src/languages/python.rs
+++ b/hodu-core/src/languages/python.rs
@@ -1,9 +1,9 @@
 use crate::{
-    sandbox::{ExecutionCommand, ExecutionResult, Sandbox},
+    sandbox::{Sandbox, SandboxCommand},
     utils::get_binary_path::get_binary_path,
 };
 
-use super::LanguageExecutor;
+use super::{ExecutionResult, ExecutionSuccessOutput, LanguageExecutor};
 
 pub struct PythonExecutor {}
 
@@ -15,7 +15,7 @@ impl LanguageExecutor for PythonExecutor {
 
         let execute_result = sandbox
             .execute(
-                ExecutionCommand {
+                SandboxCommand {
                     binary: &binary,
                     args: vec!["./main.py"],
                 },
@@ -23,6 +23,10 @@ impl LanguageExecutor for PythonExecutor {
             )
             .await;
 
-        execute_result
+        ExecutionResult::Success(ExecutionSuccessOutput {
+            stdout: execute_result.stdout,
+            stderr: execute_result.stderr,
+            time: execute_result.time,
+        })
     }
 }

--- a/hodu-core/src/lib.rs
+++ b/hodu-core/src/lib.rs
@@ -9,7 +9,7 @@ use languages::{
     c::CExecutor, cpp::CppExecutor, java::JavaExecutor, javascript::JavaScriptExecutor,
     python::PythonExecutor, ExecutionResult, LanguageExecutor,
 };
-use sandbox::{isolate::Isolate, Sandbox, SandboxEnvironment};
+use sandbox::{isolate::Isolate, Sandbox, SandboxSpecification};
 
 pub enum Language {
     C,
@@ -45,7 +45,7 @@ pub enum MarkResultStatus {
 }
 
 pub async fn mark(params: MarkParams<'_>) -> MarkResult {
-    let sandbox = Isolate::create(SandboxEnvironment {
+    let sandbox = Isolate::create(SandboxSpecification {
         memory_limit: params.memory_limit,
         time_limit: params.time_limit,
     })

--- a/hodu-core/src/lib.rs
+++ b/hodu-core/src/lib.rs
@@ -1,10 +1,79 @@
 pub mod error;
-pub use error::HoduCoreError;
-pub mod languages;
-pub use languages::{mark_code, Language};
-mod sandbox {
-    pub mod isolate;
-}
+mod languages;
+mod sandbox;
 mod utils {
     pub mod get_binary_path;
+}
+
+use languages::{
+    c::CExecutor, cpp::CppExecutor, java::JavaExecutor, javascript::JavaScriptExecutor,
+    python::PythonExecutor, LanguageExecutor,
+};
+use sandbox::{isolate::Isolate, Sandbox, SandboxEnvironment};
+
+pub enum Language {
+    C,
+    Cpp,
+    Java,
+    Python,
+    JavaScript,
+}
+
+pub struct MarkParams<'a> {
+    pub language: &'a Language,
+    pub code: &'a str,
+    pub stdin: &'a str,
+    pub expected_stdout: &'a str,
+    pub time_limit: u32,
+    pub memory_limit: u32,
+}
+
+pub struct MarkResult {
+    pub status: MarkResultStatus,
+    pub time: u32,
+    pub memory: u32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+pub enum MarkResultStatus {
+    Correct,
+    Wrong,
+    CompileError,
+    RuntimeError,
+    TimeLimitExceeded,
+    MemoryLimitExceeded,
+}
+
+pub async fn mark(params: MarkParams<'_>) -> MarkResult {
+    let sandbox = Isolate::create(SandboxEnvironment {
+        memory_limit: params.memory_limit,
+        time_limit: params.time_limit,
+    })
+    .await;
+
+    let execute_result = match params.language {
+        Language::C => CExecutor {}.run(params.code, &sandbox).await,
+        Language::Cpp => CppExecutor {}.run(params.code, &sandbox).await,
+        Language::Java => JavaExecutor {}.run(params.code, &sandbox).await,
+        Language::Python => PythonExecutor {}.run(params.code, &sandbox).await,
+        Language::JavaScript => JavaScriptExecutor {}.run(params.code, &sandbox).await,
+    };
+
+    sandbox.destroy().await;
+
+    // TODO: implement
+    MarkResult {
+        status: MarkResultStatus::Correct,
+        time: 0,
+        memory: 0,
+        stdout: match &execute_result.success {
+            true => execute_result.output.to_string(),
+            false => String::new(),
+        },
+        stderr: match &execute_result.success {
+            true => String::new(),
+            false => execute_result.output.to_string(),
+        },
+    }
 }

--- a/hodu-core/src/lib.rs
+++ b/hodu-core/src/lib.rs
@@ -7,7 +7,7 @@ mod utils {
 
 use languages::{
     c::CExecutor, cpp::CppExecutor, java::JavaExecutor, javascript::JavaScriptExecutor,
-    python::PythonExecutor, LanguageExecutor,
+    python::PythonExecutor, ExecutionResult, LanguageExecutor,
 };
 use sandbox::{isolate::Isolate, Sandbox, SandboxEnvironment};
 
@@ -30,8 +30,7 @@ pub struct MarkParams<'a> {
 
 pub struct MarkResult {
     pub status: MarkResultStatus,
-    pub time: u32,
-    pub memory: u32,
+    pub time: f64,
     pub stdout: String,
     pub stderr: String,
 }
@@ -62,18 +61,23 @@ pub async fn mark(params: MarkParams<'_>) -> MarkResult {
 
     sandbox.destroy().await;
 
-    // TODO: implement
     MarkResult {
-        status: MarkResultStatus::Correct,
-        time: 0,
-        memory: 0,
-        stdout: match &execute_result.success {
-            true => execute_result.output.to_string(),
-            false => String::new(),
+        status: match &execute_result {
+            // TODO: implement
+            ExecutionResult::Success(_) => MarkResultStatus::Correct,
+            ExecutionResult::CompileError(_) => MarkResultStatus::CompileError,
         },
-        stderr: match &execute_result.success {
-            true => String::new(),
-            false => execute_result.output.to_string(),
+        time: match &execute_result {
+            ExecutionResult::Success(result) => result.time,
+            ExecutionResult::CompileError(_) => 0.0,
+        },
+        stdout: match &execute_result {
+            ExecutionResult::Success(result) => result.stdout.clone(),
+            ExecutionResult::CompileError(result) => result.stdout.clone(),
+        },
+        stderr: match &execute_result {
+            ExecutionResult::Success(result) => result.stderr.clone(),
+            ExecutionResult::CompileError(result) => result.stderr.clone(),
         },
     }
 }

--- a/hodu-core/src/sandbox.rs
+++ b/hodu-core/src/sandbox.rs
@@ -1,0 +1,23 @@
+pub mod isolate;
+
+pub struct ExecutionCommand<'a> {
+    pub binary: &'a str,
+    pub args: Vec<&'a str>,
+}
+
+pub struct ExecutionResult {
+    pub output: String,
+    pub success: bool,
+}
+
+pub struct SandboxEnvironment {
+    pub memory_limit: u32,
+    pub time_limit: u32,
+}
+
+pub trait Sandbox {
+    async fn create(environment: SandboxEnvironment) -> Self;
+    async fn add_file(&self, filename: &str, content: &str);
+    async fn execute(&self, command: ExecutionCommand, sandboxed: bool) -> ExecutionResult;
+    async fn destroy(&self);
+}

--- a/hodu-core/src/sandbox.rs
+++ b/hodu-core/src/sandbox.rs
@@ -1,12 +1,14 @@
 pub mod isolate;
 
-pub struct ExecutionCommand<'a> {
+pub struct SandboxCommand<'a> {
     pub binary: &'a str,
     pub args: Vec<&'a str>,
 }
 
-pub struct ExecutionResult {
-    pub output: String,
+pub struct SandboxResult {
+    pub stdout: String,
+    pub stderr: String,
+    pub time: f64,
     pub success: bool,
 }
 
@@ -18,6 +20,6 @@ pub struct SandboxEnvironment {
 pub trait Sandbox {
     async fn create(environment: SandboxEnvironment) -> Self;
     async fn add_file(&self, filename: &str, content: &str);
-    async fn execute(&self, command: ExecutionCommand, sandboxed: bool) -> ExecutionResult;
+    async fn execute(&self, command: SandboxCommand, sandboxed: bool) -> SandboxResult;
     async fn destroy(&self);
 }

--- a/hodu-core/src/sandbox.rs
+++ b/hodu-core/src/sandbox.rs
@@ -12,13 +12,13 @@ pub struct SandboxResult {
     pub success: bool,
 }
 
-pub struct SandboxEnvironment {
+pub struct SandboxSpecification {
     pub memory_limit: u32,
     pub time_limit: u32,
 }
 
 pub trait Sandbox {
-    async fn create(environment: SandboxEnvironment) -> Self;
+    async fn create(environment: SandboxSpecification) -> Self;
     async fn add_file(&self, filename: &str, content: &str);
     async fn execute(&self, command: SandboxCommand, sandboxed: bool) -> SandboxResult;
     async fn destroy(&self);

--- a/hodu-core/src/sandbox/isolate.rs
+++ b/hodu-core/src/sandbox/isolate.rs
@@ -1,87 +1,88 @@
-pub use error::Error;
 use rand::Rng;
+use std::path::PathBuf;
 use tokio::process::Command;
 
-use crate::languages::{ExecutionParams, ExecutionResult};
+use super::{ExecutionCommand, ExecutionResult, Sandbox, SandboxEnvironment};
 
-pub async fn execute_isolate(params: ExecutionParams) -> Result<ExecutionResult, Error> {
-    let box_id = rand::thread_rng().gen_range(0..1000);
-    let box_id_arg = format!("--box-id={}", box_id);
+pub struct Isolate {
+    box_id: i32,
+    path: PathBuf,
+    memory_limit: u32,
+    time_limit: u32,
+}
 
-    let init_output = Command::new("isolate")
-        .arg(&box_id_arg)
-        .arg("--init")
-        .output()
-        .await
-        .map_err(Error::IsolateInitError)?;
-
-    let working_directory = format!(
-        "{}/box",
-        std::str::from_utf8(&init_output.stdout)
-            .expect("Invalid output")
-            .trim(),
-    );
-    let source_path = format!("{}/{}", working_directory, params.filename);
-
-    std::fs::write(source_path, params.code).expect("Failed to write file");
-
-    if let Some(compile_command) = params.compile_command {
-        let compile_output = Command::new(compile_command.binary)
-            .current_dir(&working_directory)
-            .args(&compile_command.args)
+impl Sandbox for Isolate {
+    async fn create(environment: SandboxEnvironment) -> Self {
+        let box_id = rand::thread_rng().gen_range(0..1000);
+        let init_output = Command::new("isolate")
+            .arg(format!("--box-id={}", box_id))
+            .arg("--init")
             .output()
             .await
-            .map_err(Error::IsolateRunError)?;
+            .expect("Failed to init box");
 
-        if !compile_output.status.success() {
-            return Ok(ExecutionResult {
-                stdout: String::new(),
-                stderr: String::from_utf8(compile_output.stderr).expect("Invalid runtime error"),
-                success: false,
-            });
+        let working_directory = format!(
+            "{}/box",
+            std::str::from_utf8(&init_output.stdout)
+                .expect("Invalid output")
+                .trim()
+        );
+
+        Isolate {
+            box_id,
+            path: PathBuf::from(working_directory),
+            memory_limit: environment.memory_limit,
+            time_limit: environment.time_limit,
         }
     }
 
-    let run_output = Command::new("isolate")
-        .arg(&box_id_arg)
-        .arg("--run")
-        .arg("-p128")
-        .arg(params.execute_command.binary)
-        .args(&params.execute_command.args)
-        .output()
-        .await
-        .map_err(Error::IsolateRunError)?;
+    async fn add_file(&self, filename: &str, content: &str) {
+        let source_path = format!("{}/{}", self.path.to_str().unwrap().trim(), filename);
 
-    Command::new("isolate")
-        .arg(&box_id_arg)
-        .arg("--cleanup")
-        .output()
-        .await
-        .map_err(Error::IsolateCleanupError)?;
-
-    if !run_output.status.success() {
-        return Ok(ExecutionResult {
-            stdout: String::new(),
-            stderr: String::from_utf8(run_output.stderr).expect("Invalid runtime error"),
-            success: false,
-        });
+        std::fs::write(source_path, content).expect("Failed to write file");
     }
 
-    Ok(ExecutionResult {
-        stdout: String::from_utf8(run_output.stdout).expect("Invalid output"),
-        stderr: String::new(),
-        success: true,
-    })
-}
+    async fn execute(&self, command: ExecutionCommand<'_>, sandboxed: bool) -> ExecutionResult {
+        let run_output = match sandboxed {
+            true => Command::new("isolate")
+                .arg(format!("--box-id={}", self.box_id))
+                .arg("--run")
+                .arg(format!("--processes={}", 128))
+                .arg(format!("--time={}", self.time_limit))
+                .arg(format!("--mem={}", self.memory_limit))
+                .arg(command.binary)
+                .args(&command.args)
+                .output()
+                .await
+                .expect("Failed to execute"),
+            false => Command::new(command.binary)
+                .args(&command.args)
+                .current_dir(&self.path)
+                .output()
+                .await
+                .expect("Failed to execute"),
+        };
 
-pub mod error {
-    #[derive(thiserror::Error, Debug)]
-    pub enum Error {
-        #[error("Error while initiating isolate")]
-        IsolateInitError(#[source] tokio::io::Error),
-        #[error("Error while running isolate")]
-        IsolateRunError(#[source] tokio::io::Error),
-        #[error("Error while cleaning up isolate")]
-        IsolateCleanupError(#[source] tokio::io::Error),
+        ExecutionResult {
+            output: match run_output.status.success() {
+                true => std::str::from_utf8(&run_output.stdout)
+                    .expect("Invalid output")
+                    .to_string(),
+
+                false => std::str::from_utf8(&run_output.stderr)
+                    .expect("Invalid output")
+                    .to_string(),
+            },
+            success: run_output.status.success(),
+        }
+    }
+
+    async fn destroy(&self) {
+        Command::new("isolate")
+            .arg(format!("--box-id={}", self.box_id))
+            .arg("--cleanup")
+            .output()
+            .await
+            .expect("Failed to cleanup box");
     }
 }

--- a/hodu-core/src/sandbox/isolate.rs
+++ b/hodu-core/src/sandbox/isolate.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 use std::path::PathBuf;
 use tokio::process::Command;
 
-use super::{Sandbox, SandboxCommand, SandboxEnvironment, SandboxResult};
+use super::{Sandbox, SandboxCommand, SandboxResult, SandboxSpecification};
 
 pub struct Isolate {
     box_id: i32,
@@ -13,7 +13,7 @@ pub struct Isolate {
 }
 
 impl Sandbox for Isolate {
-    async fn create(environment: SandboxEnvironment) -> Self {
+    async fn create(environment: SandboxSpecification) -> Self {
         let box_id = rand::thread_rng().gen_range(0..1000);
         let init_output = Command::new("isolate")
             .arg(format!("--box-id={}", box_id))

--- a/hodu-core/src/utils/get_binary_path.rs
+++ b/hodu-core/src/utils/get_binary_path.rs
@@ -14,5 +14,5 @@ pub async fn get_binary_path(binary: &str) -> String {
     let output = std::fs::canonicalize(String::from_utf8(which.stdout).unwrap().trim().to_string())
         .expect("failed");
 
-    output.to_str().unwrap().to_string()
+    output.to_str().expect("could not find binary").to_string()
 }

--- a/hodu-server/Cargo.toml
+++ b/hodu-server/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 
 [dependencies]
 hodu-core = { path = "../hodu-core" }
+
 actix-web = "4"
-tokio = { version = "1.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+thiserror = "1.0.63"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-thiserror = "1.0.63"
 
 [dependencies.uuid]
 version = "1.10.0"

--- a/hodu-server/src/api/error.rs
+++ b/hodu-server/src/api/error.rs
@@ -5,8 +5,6 @@ use serde::Serialize;
 pub enum HoduError {
     #[error("PayloadParseError: {0}")]
     PayloadParseError(#[source] actix_web::Error),
-    #[error("CodeExecutionError: {0}")]
-    CodeExecutionError(#[source] hodu_core::HoduCoreError),
 }
 
 #[derive(Serialize, Debug)]
@@ -18,7 +16,6 @@ impl ResponseError for HoduError {
     fn status_code(&self) -> StatusCode {
         match self {
             HoduError::PayloadParseError(_) => StatusCode::BAD_REQUEST,
-            HoduError::CodeExecutionError(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 

--- a/hodu-server/src/api/judge/schema.rs
+++ b/hodu-server/src/api/judge/schema.rs
@@ -1,12 +1,10 @@
-use hodu_core::Language;
-use serde::Deserialize;
 use uuid::Uuid;
 
-#[derive(Deserialize)]
+#[derive(serde::Deserialize)]
 pub struct CodeSubmission {
     #[serde(default = "default_id")]
     pub id: String,
-    pub language: Language,
+    pub language: String,
     pub code: String,
 }
 

--- a/hodu-server/src/api/judge/schema.rs
+++ b/hodu-server/src/api/judge/schema.rs
@@ -1,13 +1,28 @@
+use serde::Deserialize;
 use uuid::Uuid;
 
-#[derive(serde::Deserialize)]
+#[derive(Deserialize)]
 pub struct CodeSubmission {
     #[serde(default = "default_id")]
     pub id: String,
-    pub language: String,
+    pub language: Language,
     pub code: String,
 }
 
 fn default_id() -> String {
     Uuid::new_v4().to_string()
+}
+
+#[derive(Deserialize, Debug)]
+pub enum Language {
+    #[serde(rename = "c")]
+    C,
+    #[serde(rename = "c++")]
+    Cpp,
+    #[serde(rename = "java")]
+    Java,
+    #[serde(rename = "javascript")]
+    Javascript,
+    #[serde(rename = "python")]
+    Python,
 }

--- a/hodu-server/src/api/judge/view.rs
+++ b/hodu-server/src/api/judge/view.rs
@@ -1,7 +1,7 @@
 use actix_web::{post, web, Responder};
 use hodu_core::{mark, MarkParams};
 
-use crate::api::{error::HoduError, judge::schema::CodeSubmission};
+use crate::api::{error::HoduError, judge::schema::CodeSubmission, judge::schema::Language};
 
 #[post("/submit")]
 async fn submit_code(
@@ -15,13 +15,12 @@ async fn submit_code(
     );
 
     let output = mark(MarkParams {
-        language: match submission.language.as_str() {
-            "c" => &hodu_core::Language::C,
-            "c++" => &hodu_core::Language::Cpp,
-            "java" => &hodu_core::Language::Java,
-            "python" => &hodu_core::Language::Python,
-            "javascript" => &hodu_core::Language::JavaScript,
-            _ => panic!("Invalid language"),
+        language: match submission.language {
+            Language::C => &hodu_core::Language::C,
+            Language::Cpp => &hodu_core::Language::Cpp,
+            Language::Java => &hodu_core::Language::Java,
+            Language::Javascript => &hodu_core::Language::JavaScript,
+            Language::Python => &hodu_core::Language::Python,
         },
         code: &submission.code,
         expected_stdout: "",

--- a/hodu-server/src/api/judge/view.rs
+++ b/hodu-server/src/api/judge/view.rs
@@ -1,5 +1,5 @@
 use actix_web::{post, web, Responder};
-use hodu_core::mark_code;
+use hodu_core::{mark, MarkParams};
 
 use crate::api::{error::HoduError, judge::schema::CodeSubmission};
 
@@ -14,9 +14,25 @@ async fn submit_code(
         submission.language
     );
 
-    let output = mark_code(&submission.language, submission.code.clone())
-        .await
-        .map_err(HoduError::CodeExecutionError)?;
+    let output = mark(MarkParams {
+        language: match submission.language.as_str() {
+            "c" => &hodu_core::Language::C,
+            "c++" => &hodu_core::Language::Cpp,
+            "java" => &hodu_core::Language::Java,
+            "python" => &hodu_core::Language::Python,
+            "javascript" => &hodu_core::Language::JavaScript,
+            _ => panic!("Invalid language"),
+        },
+        code: &submission.code,
+        expected_stdout: "",
+        stdin: "",
+        memory_limit: 4096000,
+        time_limit: 10,
+    })
+    .await;
 
-    Ok(web::Json(output))
+    Result::Ok(web::Json(serde_json::json!({
+        "stdout": output.stdout,
+        "stderr": output.stderr,
+    })))
 }

--- a/hodu-server/src/api/judge/view.rs
+++ b/hodu-server/src/api/judge/view.rs
@@ -32,6 +32,15 @@ async fn submit_code(
     .await;
 
     Result::Ok(web::Json(serde_json::json!({
+        "status": match output.status {
+                hodu_core::MarkResultStatus::Correct => "correct",
+                hodu_core::MarkResultStatus::Wrong => "wrong",
+                hodu_core::MarkResultStatus::CompileError => "compile_error",
+                hodu_core::MarkResultStatus::RuntimeError => "runtime_error",
+                hodu_core::MarkResultStatus::TimeLimitExceeded => "time_limit_exceeded",
+                hodu_core::MarkResultStatus::MemoryLimitExceeded => "memory_limit_exceeded",
+            },
+        "time": output.time,
         "stdout": output.stdout,
         "stderr": output.stderr,
     })))

--- a/hodu-server/tests/bruno/[c++] stars.bru
+++ b/hodu-server/tests/bruno/[c++] stars.bru
@@ -16,7 +16,7 @@ headers {
 
 body:json {
   {
-    "language": "CPP",
+    "language": "c++",
     "code": "#include <iostream>\nint main() { for (int i = 0; i < 5; i++) { for (int j = 0; j <= i; j++) {std::cout << \"*\";}\n std::cout << \"\\n\";}\n return 0;\n}"
   }
 }

--- a/hodu-server/tests/bruno/[c] stars.bru
+++ b/hodu-server/tests/bruno/[c] stars.bru
@@ -16,7 +16,7 @@ headers {
 
 body:json {
   {
-    "language": "C",
+    "language": "c",
     "code": "#include <stdio.h>\nint main() { for (int i = 0; i < 5; i++) { for (int j = 0; j <= i; j++) {printf(\"*\");}\n printf(\"\\n\");}\n return 0;\n}"
   }
 }

--- a/hodu-server/tests/bruno/[java] single print.bru
+++ b/hodu-server/tests/bruno/[java] single print.bru
@@ -25,4 +25,5 @@ assert {
   res.status: eq 200
   res.body.stdout: eq *\n
   res.body.stderr: eq
+  res.body.status: eq correct
 }

--- a/hodu-server/tests/bruno/[java] single print.bru
+++ b/hodu-server/tests/bruno/[java] single print.bru
@@ -16,7 +16,7 @@ headers {
 
 body:json {
   {
-    "language": "JAVA",
+    "language": "java",
     "code": "public class Main { public static void main(String[] args) { System.out.println(\"*\"); } }"
   }
 }
@@ -24,5 +24,5 @@ body:json {
 assert {
   res.status: eq 200
   res.body.stdout: eq *\n
-  res.body.stderr: eq 
+  res.body.stderr: eq
 }

--- a/hodu-server/tests/bruno/[javascript] single print.bru
+++ b/hodu-server/tests/bruno/[javascript] single print.bru
@@ -16,7 +16,7 @@ headers {
 
 body:json {
   {
-    "language": "JAVASCRIPT",
+    "language": "javascript",
     "code": "console.log('Hello');"
   }
 }

--- a/hodu-server/tests/bruno/[python] single print.bru
+++ b/hodu-server/tests/bruno/[python] single print.bru
@@ -16,7 +16,7 @@ headers {
 
 body:json {
   {
-    "language": "PYTHON",
+    "language": "python",
     "code": "print(\"Hello\")"
   }
 }

--- a/hodu-server/tests/bruno/compile-errors/[c] no semicolon.bru
+++ b/hodu-server/tests/bruno/compile-errors/[c] no semicolon.bru
@@ -16,7 +16,7 @@ headers {
 
 body:json {
   {
-    "language": "C",
+    "language": "c",
     "code": "#include <stdio.h>\nint main() { printf(\"Hello World\") }"
   }
 }

--- a/hodu-server/tests/bruno/hacks/[c] memory limit - very large array.bru
+++ b/hodu-server/tests/bruno/hacks/[c] memory limit - very large array.bru
@@ -16,7 +16,7 @@ headers {
 
 body:json {
   {
-    "language": "C",
+    "language": "c",
     "code": "#include <stdlib.h>\nint result[100000][100000];\nint main() { }"
   }
 }

--- a/hodu-server/tests/bruno/hacks/[c] run shell - shutdown.bru
+++ b/hodu-server/tests/bruno/hacks/[c] run shell - shutdown.bru
@@ -16,7 +16,7 @@ headers {
 
 body:json {
   {
-    "language": "C",
+    "language": "c",
     "code": "#include <stdlib.h>\n#include <stdio.h>\nint main() { int result = system(\"shutdown\"); printf(\"%d\", result); }"
   }
 }

--- a/hodu-server/tests/bruno/hacks/[node] run shell - try to get structure.bru
+++ b/hodu-server/tests/bruno/hacks/[node] run shell - try to get structure.bru
@@ -16,7 +16,7 @@ headers {
 
 body:json {
   {
-    "language": "JAVASCRIPT",
+    "language": "javascript",
     "code": "import { exec } from 'child_process'; const execa = (cmd) => new Promise((res) => exec(cmd, (err, stdout, stderr) => res((err ? stderr : stdout).trim()))); const pwd = await execa('pwd'); console.log(pwd);"
   }
 }


### PR DESCRIPTION
## 기존 코드의 문제점
- `execute_isolate` 내부에 컴파일 로직이 섞여있어 역할이 애매하게 분리되어 있었습니다.
- API 규격상 옳지 않은 `Language`가 내려오면 serialize 단에서 잘리고 있었습니다.

## 리팩토링 방법
- `LanguageExecutor`, `Sandbox` 를 trait화하고, `lib.rs` 에서 이들을 조립하는 식으로 구현하여 역할을 명확하게 분리합니다.
- API는 langauge 를 `String` 으로 받고, 비즈니스 로직을 통해서 Language 로 변환합니다.

## 관련 링크
- https://wafflestudio.slack.com/archives/C07DDPK0TD4/p1722859668316089
- https://wafflestudio.slack.com/archives/C07DDPK0TD4/p1722870276281499
- resolve #20 