### PR TITLE
✨ 채점, compile error, runtime error, stdin 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,6 @@ jobs:
       - name: Run Tests
         working-directory: hodu-server/tests/bruno
         run: |
-          bru run
+          find . -type f -name "*.bru" | grep -v '^\./\[java\]' | while read file; do
+            bru run "$file"
+          done

--- a/hodu-core/src/languages.rs
+++ b/hodu-core/src/languages.rs
@@ -7,7 +7,12 @@ pub mod javascript;
 pub mod python;
 
 pub trait LanguageExecutor {
-    async fn run(&self, code: &str, sandbox: &impl Sandbox) -> ExecutionResult;
+    async fn run(&self, params: &ExecutionParams, sandbox: &impl Sandbox) -> ExecutionResult;
+}
+
+pub struct ExecutionParams<'a> {
+    pub code: &'a str,
+    pub stdin: &'a str,
 }
 
 pub struct ExecutionSuccessOutput {
@@ -24,4 +29,5 @@ pub struct ExecutionErrorOutput {
 pub enum ExecutionResult {
     Success(ExecutionSuccessOutput),
     CompileError(ExecutionErrorOutput),
+    RuntimeError(ExecutionErrorOutput),
 }

--- a/hodu-core/src/languages/c.rs
+++ b/hodu-core/src/languages/c.rs
@@ -1,20 +1,23 @@
-use crate::sandbox::{Sandbox, SandboxCommand};
+use crate::sandbox::{Sandbox, SandboxCommand, SandboxExecuteOptions};
 
-use super::{ExecutionErrorOutput, ExecutionResult, ExecutionSuccessOutput, LanguageExecutor};
+use super::{
+    ExecutionErrorOutput, ExecutionParams, ExecutionResult, ExecutionSuccessOutput,
+    LanguageExecutor,
+};
 
 pub struct CExecutor {}
 
 impl LanguageExecutor for CExecutor {
-    async fn run(&self, code: &str, sandbox: &impl Sandbox) -> ExecutionResult {
-        sandbox.add_file("./main.c", code).await;
+    async fn run(&self, params: &ExecutionParams<'_>, sandbox: &impl Sandbox) -> ExecutionResult {
+        sandbox.add_file("./main.c", params.code).await;
 
         let compile_result = sandbox
             .execute(
-                SandboxCommand {
+                &SandboxCommand {
                     binary: "gcc",
                     args: vec!["-o", "./main", "./main.c"],
                 },
-                false,
+                &SandboxExecuteOptions::Unsandboxed,
             )
             .await;
 
@@ -27,13 +30,22 @@ impl LanguageExecutor for CExecutor {
 
         let execute_result = sandbox
             .execute(
-                SandboxCommand {
+                &SandboxCommand {
                     binary: "./main",
                     args: vec![],
                 },
-                true,
+                &SandboxExecuteOptions::Sandboxed {
+                    stdin: params.stdin,
+                },
             )
             .await;
+
+        if !execute_result.success {
+            return ExecutionResult::RuntimeError(ExecutionErrorOutput {
+                stdout: execute_result.stdout,
+                stderr: execute_result.stderr,
+            });
+        }
 
         ExecutionResult::Success(ExecutionSuccessOutput {
             stdout: execute_result.stdout,

--- a/hodu-core/src/languages/python.rs
+++ b/hodu-core/src/languages/python.rs
@@ -1,27 +1,39 @@
 use crate::{
-    sandbox::{Sandbox, SandboxCommand},
+    sandbox::{Sandbox, SandboxCommand, SandboxExecuteOptions},
     utils::get_binary_path::get_binary_path,
 };
 
-use super::{ExecutionResult, ExecutionSuccessOutput, LanguageExecutor};
+use super::{
+    ExecutionErrorOutput, ExecutionParams, ExecutionResult, ExecutionSuccessOutput,
+    LanguageExecutor,
+};
 
 pub struct PythonExecutor {}
 
 impl LanguageExecutor for PythonExecutor {
-    async fn run(&self, code: &str, sandbox: &impl Sandbox) -> ExecutionResult {
-        sandbox.add_file("./main.py", code).await;
+    async fn run(&self, params: &ExecutionParams<'_>, sandbox: &impl Sandbox) -> ExecutionResult {
+        sandbox.add_file("./main.py", params.code).await;
 
         let binary = get_binary_path("python3").await;
 
         let execute_result = sandbox
             .execute(
-                SandboxCommand {
+                &SandboxCommand {
                     binary: &binary,
                     args: vec!["./main.py"],
                 },
-                true,
+                &SandboxExecuteOptions::Sandboxed {
+                    stdin: params.stdin,
+                },
             )
             .await;
+
+        if !execute_result.success {
+            return ExecutionResult::RuntimeError(ExecutionErrorOutput {
+                stdout: execute_result.stdout,
+                stderr: execute_result.stderr,
+            });
+        }
 
         ExecutionResult::Success(ExecutionSuccessOutput {
             stdout: execute_result.stdout,

--- a/hodu-core/src/sandbox.rs
+++ b/hodu-core/src/sandbox.rs
@@ -17,9 +17,18 @@ pub struct SandboxSpecification {
     pub time_limit: u32,
 }
 
+pub enum SandboxExecuteOptions<'a> {
+    Sandboxed { stdin: &'a str },
+    Unsandboxed,
+}
+
 pub trait Sandbox {
     async fn create(environment: SandboxSpecification) -> Self;
     async fn add_file(&self, filename: &str, content: &str);
-    async fn execute(&self, command: SandboxCommand, sandboxed: bool) -> SandboxResult;
+    async fn execute(
+        &self,
+        command: &SandboxCommand,
+        options: &SandboxExecuteOptions,
+    ) -> SandboxResult;
     async fn destroy(&self);
 }

--- a/hodu-server/src/api/judge/view.rs
+++ b/hodu-server/src/api/judge/view.rs
@@ -23,8 +23,8 @@ async fn submit_code(
             Language::Python => &hodu_core::Language::Python,
         },
         code: &submission.code,
-        expected_stdout: "",
-        stdin: "",
+        expected_stdout: "*\n",
+        stdin: "3",
         memory_limit: 4096000,
         time_limit: 10,
     })

--- a/hodu-server/tests/bruno/[c++] stars.bru
+++ b/hodu-server/tests/bruno/[c++] stars.bru
@@ -24,4 +24,6 @@ body:json {
 assert {
   res.status: eq 200
   res.body.stdout: eq *\n**\n***\n****\n*****\n
+  res.body.stderr: eq
+  res.body.status: eq wrong
 }

--- a/hodu-server/tests/bruno/[c] stars.bru
+++ b/hodu-server/tests/bruno/[c] stars.bru
@@ -17,11 +17,13 @@ headers {
 body:json {
   {
     "language": "c",
-    "code": "#include <stdio.h>\nint main() { for (int i = 0; i < 5; i++) { for (int j = 0; j <= i; j++) {printf(\"*\");}\n printf(\"\\n\");}\n return 0;\n}"
+    "code": "#include <stdio.h>\nint main() { int input; scanf(\"%d\", &input); printf(\"%d\", input + 1); }"
   }
 }
 
 assert {
   res.status: eq 200
-  res.body.stdout: eq *\n**\n***\n****\n*****\n
+  res.body.stdout: eq "4"
+  res.body.stderr: eq 
+  res.body.status: eq wrong
 }

--- a/hodu-server/tests/bruno/[javascript] single print.bru
+++ b/hodu-server/tests/bruno/[javascript] single print.bru
@@ -24,4 +24,6 @@ body:json {
 assert {
   res.status: eq 200
   res.body.stdout: eq Hello\n
+  res.body.stderr: eq
+  res.body.status: eq wrong
 }

--- a/hodu-server/tests/bruno/[python] single print.bru
+++ b/hodu-server/tests/bruno/[python] single print.bru
@@ -24,4 +24,6 @@ body:json {
 assert {
   res.status: eq 200
   res.body.stdout: eq Hello\n
+  res.body.stderr: eq
+  res.body.status: eq wrong
 }

--- a/hodu-server/tests/bruno/compile-errors/[c] no semicolon.bru
+++ b/hodu-server/tests/bruno/compile-errors/[c] no semicolon.bru
@@ -24,4 +24,6 @@ body:json {
 assert {
   res.status: eq 200
   res.body.stdout: eq ""
+  res.body.stderr: neq 
+  res.body.status: eq compile_error
 }

--- a/hodu-server/tests/bruno/hacks/[c] run shell - shutdown.bru
+++ b/hodu-server/tests/bruno/hacks/[c] run shell - shutdown.bru
@@ -23,6 +23,8 @@ body:json {
 
 assert {
   res.status: eq 200
+  res.body.stderr: eq
+  res.body.status: eq wrong
 }
 
 tests {

--- a/hodu-server/tests/bruno/hacks/[node] run shell - try to get structure.bru
+++ b/hodu-server/tests/bruno/hacks/[node] run shell - try to get structure.bru
@@ -24,4 +24,6 @@ body:json {
 assert {
   res.status: eq 200
   res.body.stdout: eq /box\n
+  res.body.stderr: eq
+  res.body.status: eq wrong
 }


### PR DESCRIPTION
## 추가된 기능

- 채점, compile error, runtime error, stdin 구현합니다.
- `--mem` 옵션 일단 줍니다. ci에서 `[java]` 는 돌리지 않도록 변경합니다.

## 테스트 방법

- `bru run`
- 테스트를 위해 `hodu-server` 쪽에서 `expected_stdout` 과 `stdin` 등을 하드코딩했습니다. 해당 부분 구현되면 api 테케들 와장창 바뀌어야 할 예정입니다.


